### PR TITLE
fix(auth): Replace manual token refresh with Clerk's internal token management

### DIFF
--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -113,7 +113,8 @@ interface AuthStoreState {
   isAuthenticated: boolean;
   user: User | null;
   sessionId: string | null;
-  token: string | null;
+  // Token management is handled entirely by Clerk's getToken() method
+  // which provides automatic refresh and caching. See Apollo auth link.
 
   // Extended state
   profile: Profile | null;
@@ -219,7 +220,6 @@ export const useAuthStore = create<AuthStoreState>()(
         isAuthenticated: false,
         user: null,
         sessionId: null,
-        token: null,
 
         // Initial extended state
         profile: null,
@@ -239,7 +239,8 @@ export const useAuthStore = create<AuthStoreState>()(
               isAuthenticated: true,
               user,
               sessionId,
-              token: null, // Token is managed by Clerk internally
+              // Token management is handled entirely by Clerk's getToken() method
+              // which provides automatic refresh and caching. See Apollo auth link.
             },
             false,
             'auth/setAuthenticated'
@@ -252,7 +253,6 @@ export const useAuthStore = create<AuthStoreState>()(
               isAuthenticated: false,
               user: null,
               sessionId: null,
-              token: null,
             },
             false,
             'auth/setUnauthenticated'
@@ -265,7 +265,6 @@ export const useAuthStore = create<AuthStoreState>()(
               isAuthenticated: false,
               user: null,
               sessionId: null,
-              token: null,
               profile: null,
               preferences: null,
               onboarding: null,

--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -127,9 +127,8 @@ interface AuthStoreState {
   isOnboardingLoaded: boolean;
 
   // Authentication actions
-  setAuthenticated: (user: User, sessionId: string, token: string) => void;
+  setAuthenticated: (user: User, sessionId: string) => void;
   setUnauthenticated: () => void;
-  updateToken: (token: string) => void;
   clearAuth: () => void;
 
   // Profile actions
@@ -234,13 +233,13 @@ export const useAuthStore = create<AuthStoreState>()(
         isOnboardingLoaded: false,
 
         // Authentication actions
-        setAuthenticated: (user, sessionId, token) => {
+        setAuthenticated: (user, sessionId) => {
           set(
             {
               isAuthenticated: true,
               user,
               sessionId,
-              token,
+              token: null, // Token is managed by Clerk internally
             },
             false,
             'auth/setAuthenticated'
@@ -257,17 +256,6 @@ export const useAuthStore = create<AuthStoreState>()(
             },
             false,
             'auth/setUnauthenticated'
-          );
-        },
-
-        updateToken: (token) => {
-          set(
-            (state) => ({
-              ...state,
-              token,
-            }),
-            false,
-            'auth/updateToken'
           );
         },
 


### PR DESCRIPTION
## 📋 Overview

This PR implements the refactoring described in issue #61 to replace our manual 55-second token refresh interval with Clerk's built-in token management capabilities.

## 🎯 Changes Made

### 1. **Removed Manual Token Refresh** (`src/components/AuthSync.tsx`)
- ✅ Deleted the 55-second `setInterval` that was manually refreshing tokens
- ✅ Removed unnecessary cleanup logic and mounted state tracking
- ✅ Eliminated redundant token refresh operations

### 2. **Simplified Authentication Flow** (`src/components/AuthSync.tsx`)
- ✅ Removed `getToken()` call from initial authentication sync
- ✅ Updated `setAuthenticated` to only require `user` and `sessionId` parameters
- ✅ Preserved user initialization and onboarding flows

### 3. **Updated Auth Store** (`src/store/auth.store.ts`)
- ✅ Modified `setAuthenticated` method signature to remove token parameter
- ✅ Removed `updateToken` method entirely
- ✅ Token field now set to `null` with documentation explaining Clerk manages tokens

### 4. **Verified Apollo Client Integration** (`src/lib/apollo/`)
- ✅ Confirmed Apollo client uses `getToken()` directly from Clerk
- ✅ Verified on-demand token fetching for each GraphQL request
- ✅ Ensured proper error handling and Bearer token headers

## ✨ Benefits

1. **Simpler Code**: Removed 25+ lines of unnecessary token management logic
2. **Better Performance**: Eliminated redundant token refresh operations every 55 seconds
3. **Improved Reliability**: Leverages Clerk's battle-tested internal token management
4. **Future-proof**: Automatically benefits from Clerk SDK improvements
5. **Reduced Maintenance**: No need to manage intervals and cleanup

## 🧪 Testing

- [x] TypeScript compilation passes (`yarn tsc --noEmit`)
- [x] ESLint checks pass (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] No security vulnerabilities (`yarn audit`)
- [x] Pre-commit and pre-push hooks pass

## 📊 Performance Impact

- **Before**: Manual refresh every 55 seconds regardless of usage
- **After**: Token fetched only when needed (on API calls)
- **Clerk caching**: Internal 60-second cache prevents redundant network calls
- **Result**: Fewer unnecessary token refreshes, same or better performance

## 🔍 How Clerk's Token Management Works

- Clerk JWTs have a **60-second TTL** for security
- `getToken()` internally caches tokens and only makes network requests when expired
- Clerk automatically handles token refresh behind the scenes
- The SDK manages all edge cases and error scenarios

## 🔗 References

- Closes #61
- [Clerk Session Tokens Documentation](https://clerk.com/docs/backend-requests/resources/session-tokens)
- [Clerk Force Token Refresh Guide](https://clerk.com/docs/guides/force-token-refresh)

## 📝 Additional Notes

This change aligns with Clerk's recommended best practices and eliminates the manual token refresh that was competing with Clerk's internal 60-second refresh cycle. The Apollo GraphQL client continues to function correctly as it uses `getToken()` directly from Clerk's authentication hooks.

🤖 Generated with [Claude Code](https://claude.ai/code)